### PR TITLE
Adding e-infra_cz prompt handlers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,7 @@ git_bob.prompt_handlers =
     kisski = git_bob._endpoints:prompt_kisski
     blablador = git_bob._endpoints:prompt_blablador
     deepseek = git_bob._endpoints:prompt_deepseek
+    e-infra_cz = git_bob._endpoints:prompt_e_infra_cz
 
 git_bob.triggers =
     review = git_bob._ai_github_utilities:review_pull_request

--- a/src/git_bob/_endpoints.py
+++ b/src/git_bob/_endpoints.py
@@ -328,3 +328,16 @@ def text_to_speech_openai(text:str, filename:str, model:str="tts-1", voice:str="
     # Save the audio file
     response.stream_to_file(filename)
 
+
+def prompt_e_infra_cz(message: str, model="llama3.3:latest", image=None):
+    """A prompt helper function that sends a message to e-infra_cz
+    and returns only the text response.
+    """
+    import os
+    from ._utilities import image_to_url
+
+    base_url = "https://chat.ai.e-infra.cz/api/"
+    api_key = os.environ.get("E-INFRA_CZ_API_KEY")
+    model = model.replace("e-infra_cz:", "")
+
+    return prompt_openai(message, model=model, image=image, base_url=base_url, api_key=api_key)


### PR DESCRIPTION
Related to #1

Add e-infra_cz prompt handler function and configuration.

use `e-infra_cz:llama3.3:latest`

* **setup.cfg**
  - Add `e-infra_cz` entry to `git_bob.prompt_handlers` section.

* **src/git_bob/_endpoints.py**
  - Implement `prompt_e_infra_cz` function with specified parameters.
  - Use `E-INFRA_CZ_API_KEY` for authentication.
  - Set `base_url` to `https://chat.ai.e-infra.cz/api/`.
  - Set `model` to `llama3.3:latest`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/martinschatz-cz/git-bob/pull/2?shareId=c7620fd3-ebb0-4179-bed8-e379488662f0).